### PR TITLE
Use casts for accessing anonymous unions

### DIFF
--- a/libyaml/include/yaml.h
+++ b/libyaml/include/yaml.h
@@ -390,13 +390,13 @@ typedef struct yaml_event_s {
     union {
         
         /** The stream parameters (for @c YAML_STREAM_START_EVENT). */
-        struct {
+        struct yaml_event_stream_start {
             /** The document encoding. */
             yaml_encoding_t encoding;
         } stream_start;
 
         /** The document parameters (for @c YAML_DOCUMENT_START_EVENT). */
-        struct {
+        struct yaml_event_document_start {
             /** The version directive. */
             yaml_version_directive_t *version_directive;
 
@@ -413,19 +413,19 @@ typedef struct yaml_event_s {
         } document_start;
 
         /** The document end parameters (for @c YAML_DOCUMENT_END_EVENT). */
-        struct {
+        struct yaml_event_document_end {
             /** Is the document end indicator implicit? */
             int implicit;
         } document_end;
 
         /** The alias parameters (for @c YAML_ALIAS_EVENT). */
-        struct {
+        struct yaml_event_alias {
             /** The anchor. */
             yaml_char_t *anchor;
         } alias;
 
         /** The scalar parameters (for @c YAML_SCALAR_EVENT). */
-        struct {
+        struct yaml_event_scalar {
             /** The anchor. */
             yaml_char_t *anchor;
             /** The tag. */
@@ -443,7 +443,7 @@ typedef struct yaml_event_s {
         } scalar;
 
         /** The sequence parameters (for @c YAML_SEQUENCE_START_EVENT). */
-        struct {
+        struct yaml_event_sequence_start {
             /** The anchor. */
             yaml_char_t *anchor;
             /** The tag. */
@@ -455,7 +455,7 @@ typedef struct yaml_event_s {
         } sequence_start;
 
         /** The mapping parameters (for @c YAML_MAPPING_START_EVENT). */
-        struct {
+        struct yaml_event_mapping_start {
             /** The anchor. */
             yaml_char_t *anchor;
             /** The tag. */
@@ -474,6 +474,14 @@ typedef struct yaml_event_s {
     yaml_mark_t end_mark;
 
 } yaml_event_t;
+
+typedef struct yaml_event_stream_start yaml_event_stream_start_t;
+typedef struct yaml_event_document_start yaml_event_document_start_t;
+typedef struct yaml_event_document_end yaml_event_document_end_t;
+typedef struct yaml_event_sequence_start yaml_event_sequence_start_t;
+typedef struct yaml_event_mapping_start yaml_event_mapping_start_t;
+typedef struct yaml_event_alias yaml_event_alias_t;
+typedef struct yaml_event_scalar yaml_event_scalar_t;
 
 /**
  * Create the STREAM-START event.

--- a/src/libyaml-1.0.vapi
+++ b/src/libyaml-1.0.vapi
@@ -138,53 +138,61 @@ namespace YAML {
 		MAPPING_END_EVENT
 	}
 
-	[CCode (cname="yaml_event_alias_t", has_type_id = false)]
-	public struct EventAlias {
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventAlias : Event {
+		[CCode (cname="data.alias.anchor")]
 		public string anchor;
 	}
 
-	[CCode (cname="yaml_event_sequence_start_t", has_type_id = false)]
-	public struct EventSequenceStart {
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventSequenceStart : Event {
+		[CCode (cname="data.sequence_start.anchor")]
 		public string anchor;
+		[CCode (cname="data.sequence_start.tag")]
 		public string tag;
+		[CCode (cname="data.sequence_start.implicity")]
 		public int implicity;
+		[CCode (cname="data.sequence_start.style")]
 		public YAML.SequenceStyle style;
 	}
 
-	[CCode (cname="yaml_event_mapping_start_t", has_type_id = false)]
-	public struct EventMappingStart {
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventMappingStart : Event {
+		[CCode (cname="data.mapping_start.anchor")]
 		public string anchor;
+		[CCode (cname="data.mapping_start.tag")]
 		public string tag;
+		[CCode (cname="data.mapping_start.implicity")]
 		public int implicity;
+		[CCode (cname="data.mapping_start.style")]
 		public YAML.MappingStyle style;
 	}
 
-	/** 
-	 * The scalar parameters (for @c YAML_SCALAR_EVENT). 
+	/**
+	 * The scalar parameters (for @c YAML_SCALAR_EVENT).
 	 * */
-	[CCode (cname="yaml_event_scalar_t", has_type_id = false)]
-	public struct EventScalar {
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventScalar : Event {
 		/* The anchor. */
+		[CCode (cname="data.scalar.anchor")]
 		public string anchor;
 		/* The tag. */
+		[CCode (cname="data.scalar.tag")]
 		public string tag;
 		/* The scalar value. */
+		[CCode (cname="data.scalar.value")]
 		public string value;
 		/* The length of the scalar value. */
+		[CCode (cname="data.scalar.length")]
 		public size_t length;
 		/* Is the tag optional for the plain style? */
+		[CCode (cname="data.scalar.plain_implicit")]
 		public int plain_implicit;
 		/* Is the tag optional for any non-plain style? */
+		[CCode (cname="data.scalar.quoted_implicit")]
 		public int quoted_implicit;
+		[CCode (cname="data.scalar.style")]
 		public ScalarStyle style;
-	}
-
-	[CCode (cname="yaml_event_data_t", has_type_id = false)]
-	public struct EventData {
-		public YAML.EventAlias alias;
-		public YAML.EventScalar scalar;
-		public YAML.EventSequenceStart sequence_start;
-		public YAML.EventMappingStart mapping_start;
 	}
 
 	[CCode (has_type_id = false,
@@ -227,14 +235,6 @@ namespace YAML {
 			event.type = YAML.EventType.NO_EVENT;
 		}
 		public EventType type;
-        [CCode (cname="data.alias")]
-		public YAML.EventAlias alias;
-        [CCode (cname="data.scalar")]
-		public YAML.EventScalar scalar;
-        [CCode (cname="data.sequence_start")]
-		public YAML.EventSequenceStart sequence_start;
-        [CCode (cname="data.mapping_start")]
-		public YAML.EventMappingStart mapping_start;
 		public Mark start_mark;
 		public Mark end_mark;
 

--- a/src/libyaml-1.0.vapi
+++ b/src/libyaml-1.0.vapi
@@ -138,12 +138,12 @@ namespace YAML {
 		MAPPING_END_EVENT
 	}
 
-	[CCode (has_type_id = false)]
+	[CCode (cname="yaml_event_alias_t", has_type_id = false)]
 	public struct EventAlias {
 		public string anchor;
 	}
 
-	[CCode (has_type_id = false)]
+	[CCode (cname="yaml_event_sequence_start_t", has_type_id = false)]
 	public struct EventSequenceStart {
 		public string anchor;
 		public string tag;
@@ -151,7 +151,7 @@ namespace YAML {
 		public YAML.SequenceStyle style;
 	}
 
-	[CCode (has_type_id = false)]
+	[CCode (cname="yaml_event_mapping_start_t", has_type_id = false)]
 	public struct EventMappingStart {
 		public string anchor;
 		public string tag;
@@ -162,7 +162,7 @@ namespace YAML {
 	/** 
 	 * The scalar parameters (for @c YAML_SCALAR_EVENT). 
 	 * */
-	[CCode (has_type_id = false)]
+	[CCode (cname="yaml_event_scalar_t", has_type_id = false)]
 	public struct EventScalar {
 		/* The anchor. */
 		public string anchor;
@@ -179,7 +179,7 @@ namespace YAML {
 		public ScalarStyle style;
 	}
 
-	[CCode (has_type_id=false)]
+	[CCode (cname="yaml_event_data_t", has_type_id = false)]
 	public struct EventData {
 		public YAML.EventAlias alias;
 		public YAML.EventScalar scalar;
@@ -227,7 +227,14 @@ namespace YAML {
 			event.type = YAML.EventType.NO_EVENT;
 		}
 		public EventType type;
-		public YAML.EventData data;
+        [CCode (cname="data.alias")]
+		public YAML.EventAlias alias;
+        [CCode (cname="data.scalar")]
+		public YAML.EventScalar scalar;
+        [CCode (cname="data.sequence_start")]
+		public YAML.EventSequenceStart sequence_start;
+        [CCode (cname="data.mapping_start")]
+		public YAML.EventMappingStart mapping_start;
 		public Mark start_mark;
 		public Mark end_mark;
 

--- a/src/loader.vala
+++ b/src/loader.vala
@@ -121,7 +121,7 @@ using YAML;
 		public Node? load_alias(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Alias node = new Node.Alias();
-			node.anchor = event.data.alias.anchor;
+			node.anchor = event.alias.anchor;
 
 			/* Push the node to the document stack
 			 * Do not register the anchor because it is an alias */
@@ -138,11 +138,11 @@ using YAML;
 		public Node? load_scalar(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Scalar node = new Node.Scalar();
-			node.anchor = event.data.scalar.anchor;
-			node.tag = normalize_tag(event.data.scalar.tag,
+			node.anchor = event.scalar.anchor;
+			node.tag = normalize_tag(event.scalar.tag,
 					DEFAULT_SCALAR_TAG);
-			node.value = event.data.scalar.value;
-			node.style = event.data.scalar.style;
+			node.value = event.scalar.value;
+			node.style = event.scalar.style;
 			node.start_mark = event.start_mark;
 			node.end_mark = event.end_mark;
 
@@ -156,10 +156,10 @@ using YAML;
 		public Node? load_sequence(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Sequence node = new Node.Sequence();
-			node.anchor = event.data.sequence_start.anchor;
-			node.tag = normalize_tag(event.data.sequence_start.tag,
+			node.anchor = event.sequence_start.anchor;
+			node.tag = normalize_tag(event.sequence_start.tag,
 					DEFAULT_SEQUENCE_TAG);
-			node.style = event.data.sequence_start.style;
+			node.style = event.sequence_start.style;
 			node.start_mark = event.start_mark;
 			node.end_mark = event.end_mark;
 
@@ -188,10 +188,10 @@ using YAML;
 		public Node? load_mapping(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Mapping node = new Node.Mapping();
-			node.tag = normalize_tag(event.data.mapping_start.tag,
+			node.tag = normalize_tag(event.mapping_start.tag,
 					DEFAULT_MAPPING_TAG);
-			node.anchor = event.data.mapping_start.anchor;
-			node.style = event.data.mapping_start.style;
+			node.anchor = event.mapping_start.anchor;
+			node.style = event.mapping_start.style;
 			node.start_mark = event.start_mark;
 			node.end_mark = event.end_mark;
 

--- a/src/loader.vala
+++ b/src/loader.vala
@@ -121,7 +121,7 @@ using YAML;
 		public Node? load_alias(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Alias node = new Node.Alias();
-			node.anchor = event.alias.anchor;
+			node.anchor = ((EventAlias) event).anchor;
 
 			/* Push the node to the document stack
 			 * Do not register the anchor because it is an alias */
@@ -138,11 +138,11 @@ using YAML;
 		public Node? load_scalar(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Scalar node = new Node.Scalar();
-			node.anchor = event.scalar.anchor;
-			node.tag = normalize_tag(event.scalar.tag,
+			node.anchor = ((EventScalar) event).anchor;
+			node.tag = normalize_tag(((EventScalar) event).tag,
 					DEFAULT_SCALAR_TAG);
-			node.value = event.scalar.value;
-			node.style = event.scalar.style;
+			node.value = ((EventScalar) event).value;
+			node.style = ((EventScalar) event).style;
 			node.start_mark = event.start_mark;
 			node.end_mark = event.end_mark;
 
@@ -156,10 +156,10 @@ using YAML;
 		public Node? load_sequence(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Sequence node = new Node.Sequence();
-			node.anchor = event.sequence_start.anchor;
-			node.tag = normalize_tag(event.sequence_start.tag,
+			node.anchor = ((EventSequenceStart) event).anchor;
+			node.tag = normalize_tag(((EventSequenceStart) event).tag,
 					DEFAULT_SEQUENCE_TAG);
-			node.style = event.sequence_start.style;
+			node.style = ((EventSequenceStart) event).style;
 			node.start_mark = event.start_mark;
 			node.end_mark = event.end_mark;
 
@@ -188,10 +188,10 @@ using YAML;
 		public Node? load_mapping(ref Parser parser, ref Event event)
 		throws Yaml.Exception {
 			Node.Mapping node = new Node.Mapping();
-			node.tag = normalize_tag(event.mapping_start.tag,
+			node.tag = normalize_tag(((EventMappingStart) event).tag,
 					DEFAULT_MAPPING_TAG);
-			node.anchor = event.mapping_start.anchor;
-			node.style = event.mapping_start.style;
+			node.anchor = ((EventMappingStart) event).anchor;
+			node.style = ((EventMappingStart) event).style;
 			node.start_mark = event.start_mark;
 			node.end_mark = event.end_mark;
 

--- a/tests/libyaml-glib-parser.vala
+++ b/tests/libyaml-glib-parser.vala
@@ -1,15 +1,17 @@
 using YAML;
-using GLib.YAML;
+using Yaml;
 const string buffer =
 """
 # This is the YAML 1.1 example. The YAML 1.2 example fails.
---- !<tag:clarkevans.com,2002:invoice>
+--- !Invoice
+status : SHIPPED | CANCELLED 
 invoice: 34843
 date   : 2001-01-23
 bill-to: &id001
     given  : Chris
     family : Dumars
-    address:
+    address: !PaypalAddress
+        verified: true
         lines: |
             458 Walkman Dr.
             Suite #292
@@ -33,58 +35,61 @@ comments:
     Backup contact is Nancy
     Billsmer @ 338-4338.
 
+
 """;
 bool use_internal = false;
 [CCode (array_length = false, array_null_terminated = true)]
 string[] filename = null;
 const OptionEntry[] options = {
-	{"internal", 'i', 0, OptionArg.NONE, ref use_internal, "Use the internal Yaml 1.1 example"},
-	{"",0, 0, OptionArg.FILENAME_ARRAY, ref filename, "the file to be parsed"}
+    {"internal", 'i', 0, OptionArg.NONE, ref use_internal, "Use the internal Yaml 1.1 example", null},
+    {"",0, 0, OptionArg.FILENAME_ARRAY, ref filename, "the file to be parsed", null},
+    {null}
 };
 
 FileStream stream = null;
 
 public int main(string[] args) {
-	OptionContext context = new OptionContext(" - test the parser");
-	context.add_main_entries (options, null);
-	context.parse(ref args);
+    OptionContext context = new OptionContext(" - test the parser");
+    context.add_main_entries (options, null);
+    context.parse(ref args);
 
-	Parser parser = Parser();
-	
-	if(use_internal)
-		parser.set_input_string(buffer, buffer.length);
-	else if(filename != null) {
-		stream = FileStream.open(filename[0], "r");
-		assert(filename.length == 1);
-		assert(stream != null);
-	}
-	if(stream != null)
-		parser.set_input_file(stream);
-	else 
-		parser.set_input_file(stdin);
+    YAML.Parser parser = YAML.Parser();
 
-	try {
-		Document document = new Document.from_parser(ref parser);
-		foreach(GLib.YAML.Node node in document.nodes) {
-			if(node is GLib.YAML.Node.Scalar) {
-				message("node:(%p) %s", node, (node as GLib.YAML.Node.Scalar).value);
-			} else
-			if(node is GLib.YAML.Node.Alias) {
-				message("alias:(%p) %s -> %p", 
-					node,
-					(node as GLib.YAML.Node.Alias).node.anchor,
-					(node as GLib.YAML.Node.Alias).get_resolved()
-				);
-			} else 
-			if(node is GLib.YAML.Node.Mapping) {
-				message("mapping:(%p)", node);
-			} else 
-			if(node is GLib.YAML.Node.Sequence) {
-				message("sequence:(%p)", node);
-			}
-		}
-	} catch (GLib.Error e) {
-		message("error message: %s", e.message);
-	}
-	return 0;
+    if(use_internal)
+        parser.set_input_string(buffer, buffer.length);
+    else {
+        if(filename != null) {
+            stream = FileStream.open(filename[0], "r");
+            assert(filename.length == 1);
+            assert(stream != null);
+        }
+        if(stream != null)
+            parser.set_input_file(stream);
+        else
+            parser.set_input_file(stdin);
+    }
+    try {
+        Document document = new Document.from_parser(ref parser);
+        foreach(Yaml.Node node in document.nodes) {
+            if(node is Yaml.Node.Scalar) {
+                message("node:(%p) %s", node, (node as Yaml.Node.Scalar).value);
+            } else
+                if(node is Yaml.Node.Alias) {
+                    message("alias:(%p) %s -> %p", 
+                            node,
+                            (node as Yaml.Node.Alias).node.anchor,
+                            (node as Yaml.Node.Alias).get_resolved()
+                           );
+                } else 
+                    if(node is Yaml.Node.Mapping) {
+                        message("mapping:(%p)", node);
+                    } else 
+                        if(node is Yaml.Node.Sequence) {
+                            message("sequence:(%p)", node);
+                        }
+        }
+    } catch (Error e) {
+        message("error message: %s", e.message);
+    }
+    return 0;
 }


### PR DESCRIPTION
Reuse the same 'cname' for all the structs and proxy their member with dot-accesses. If one want to have a specific type in the union, it is sufficient to cast to the desired type.

It's a bit cleaner because it does not require changes in libyaml sources. I think we could also use struct inheritance to inherit properties from `YAML.Event` and make the cast less evil.

I suggest that you revert c2f0042b2bcdae90f02d28578ddc41ce1f25ad6d in order to merge this commit.