### PR TITLE
Switch build system to Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,10 @@
+project('YAML-GLib', 'c', 'vala',
+        version: '0.1.1')
+
+glib = dependency('glib-2.0', version: '>=2.32')
+gobject = dependency('gobject-2.0', version: '>=2.32')
+gmodule = dependency('gmodule-2.0', version: '>=2.32')
+yaml = dependency('yaml-0.1', version: '>=0.1.4')
+
+subdir('src')
+subdir('tests')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,25 @@
+yaml_glib_sources = [
+    'buildable.vala',
+    'builder.vala',
+    'error.vala',
+    'libyaml-glib.vala',
+    'loader.vala',
+    'writer.vala']
+yaml_glib_lib = library('yaml-glib-1.0', yaml_glib_sources,
+                    vala_args: ['--vapidir=' + meson.current_source_dir()],
+                    dependencies: [glib, gobject, gmodule, yaml],
+                    install: true)
+
+yaml_glib = declare_dependency(link_with: yaml_glib_lib,
+                               include_directories: include_directories('.'))
+
+install_headers('yaml-glib-1.0.h')
+install_data([meson.current_build_dir() + '/yaml-glib-1.0.vapi', 'yaml-glib-1.0.deps'],
+             install_dir: 'share/vala/vapi')
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(name: 'yaml-glib-1.0',
+                   description: 'Building GObjects from YAML',
+                   version: meson.project_version(),
+                   requires: 'yaml-0.1',
+                   libraries: yaml_glib_lib)

--- a/src/yaml-0.1.vapi
+++ b/src/yaml-0.1.vapi
@@ -1,0 +1,364 @@
+/* ************
+ *
+ * Copyright (C) 2009  Denis Tereshkin
+ * Copyright (C) 2009  Dmitriy Kuteynikov
+ * Copyright (C) 2009  Yu Feng
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to 
+ *
+ * the Free Software Foundation, Inc., 
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+ *
+ * Author:
+ * 	Denis Tereshkin
+ * 	Dmitriy Kuteynikov <kuteynikov@gmail.com>
+ * 	Yu Feng <rainwoodman@gmail.com>
+ ***/
+
+[CCode (cprefix="YAML", cheader_filename="yaml.h", lower_case_cprefix="yaml_")]
+namespace YAML {
+
+	public const string DEFAULT_SCALAR_TAG;
+	public const string DEFAULT_SEQUENCE_TAG;
+	public const string DEFAULT_MAPPING_TAG;
+	public const string NULL_TAG;
+	public const string BOOL_TAG;
+	public const string STR_TAG;
+	public const string INT_TAG;
+	public const string FLOAT_TAG;
+	public const string TIMESTAMP_TAG;
+	public const string SEQ_TAG;
+	public const string MAP_TAG;
+
+	[CCode (cprefix="YAML_", cname="yaml_node_type_t", has_type_id=false)]
+	public enum NodeType {
+		NO_NODE,
+		SCALAR_NODE,
+		SEQUENCE_NODE,
+		MAPPING_NODE
+	}
+	[CCode (cprefix="YAML_", cname="yaml_scalar_style_t", has_type_id=false)]
+	public enum ScalarStyle {
+		ANY_SCALAR_STYLE,
+		PLAIN_SCALAR_STYLE,
+		SINGLE_QUOTED_SCALAR_STYLE,
+		DOUBLE_QUOTED_SCALAR_STYLE,
+		LITERAL_SCALAR_STYLE,
+		FOLDED_SCALAR_STYLE
+	}
+
+	[CCode (cprefix="YAML_", cname="yaml_sequence_style_t", has_type_id=false)]
+	/** 
+	 * Sequence styles 
+	 * */
+	public enum SequenceStyle{
+		ANY_SEQUENCE_STYLE ,
+		BLOCK_SEQUENCE_STYLE,
+		FLOW_SEQUENCE_STYLE
+	}
+	/** 
+	 * Mapping styles. 
+	 * */
+	[CCode (cprefix="YAML_", cname="yaml_mapping_style_t", has_type_id=false)]
+	public enum MappingStyle {
+		ANY_MAPPING_STYLE,
+		BLOCK_MAPPING_STYLE,
+		FLOW_MAPPING_STYLE
+	}
+
+	/** 
+	 * The version directive data. 
+	 * */
+	[CCode (cname="yaml_version_directive_t", has_type_id = false)]
+	public struct VersionDirective {
+		public int major;
+		public int minor;
+	}
+
+	/** 
+	 * The tag directive data. 
+	 * */
+	[CCode (cname = "yaml_tag_directive_t", has_type_id = false)]
+	public struct TagDirective {
+		public string handle;
+		public string prefix;
+	}
+	/** Line break types. */
+
+	[CCode (cprefix="YAML_", cname="yaml_break_t", has_type_id=false)]
+	public enum BreakType {
+		ANY_BREAK,
+		CR_BREAK,
+		LN_BREAK,
+		CRLN_BREAK
+	}
+
+	[CCode (cname="yaml_mark_t", has_type_id = false)]
+	/** 
+	 * The pointer position. 
+	 * */
+	public struct Mark {
+		public size_t index;
+		public size_t line;
+		public size_t column;
+		public string to_string() {
+			return "index:%u line:%u column:%u".printf(
+				(uint)index, (uint)line, (uint)column);
+		}
+	}
+
+	[CCode (cname = "yaml_event_type_t", cprefix="YAML_", has_type_id = false)]
+	public enum EventType {
+		NO_EVENT,
+
+		STREAM_START_EVENT,
+		STREAM_END_EVENT,
+
+		DOCUMENT_START_EVENT,
+		DOCUMENT_END_EVENT,
+
+		ALIAS_EVENT,
+		SCALAR_EVENT,
+
+		SEQUENCE_START_EVENT,
+		SEQUENCE_END_EVENT,
+
+		MAPPING_START_EVENT,
+		MAPPING_END_EVENT
+	}
+
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventAlias : Event {
+		[CCode (cname="data.alias.anchor")]
+		public string anchor;
+	}
+
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventSequenceStart : Event {
+		[CCode (cname="data.sequence_start.anchor")]
+		public string anchor;
+		[CCode (cname="data.sequence_start.tag")]
+		public string tag;
+		[CCode (cname="data.sequence_start.implicity")]
+		public int implicity;
+		[CCode (cname="data.sequence_start.style")]
+		public YAML.SequenceStyle style;
+	}
+
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventMappingStart : Event {
+		[CCode (cname="data.mapping_start.anchor")]
+		public string anchor;
+		[CCode (cname="data.mapping_start.tag")]
+		public string tag;
+		[CCode (cname="data.mapping_start.implicity")]
+		public int implicity;
+		[CCode (cname="data.mapping_start.style")]
+		public YAML.MappingStyle style;
+	}
+
+	/**
+	 * The scalar parameters (for @c YAML_SCALAR_EVENT).
+	 * */
+	[CCode (cname="yaml_event_t", has_type_id = false)]
+	public struct EventScalar : Event {
+		/* The anchor. */
+		[CCode (cname="data.scalar.anchor")]
+		public string anchor;
+		/* The tag. */
+		[CCode (cname="data.scalar.tag")]
+		public string tag;
+		/* The scalar value. */
+		[CCode (cname="data.scalar.value")]
+		public string value;
+		/* The length of the scalar value. */
+		[CCode (cname="data.scalar.length")]
+		public size_t length;
+		/* Is the tag optional for the plain style? */
+		[CCode (cname="data.scalar.plain_implicit")]
+		public int plain_implicit;
+		/* Is the tag optional for any non-plain style? */
+		[CCode (cname="data.scalar.quoted_implicit")]
+		public int quoted_implicit;
+		[CCode (cname="data.scalar.style")]
+		public ScalarStyle style;
+	}
+
+	[CCode (has_type_id = false,
+			cname="yaml_event_t", 
+			lower_case_cprefix="yaml_event_",
+			destroy_function="yaml_event_delete")]
+	public struct Event {
+		[CCode (cname="yaml_stream_start_event_initialize")]
+		public static int stream_start_initialize(ref YAML.Event event, YAML.EncodingType encoding);
+
+		[CCode (cname="yaml_stream_end_event_initialize")]
+		public static int stream_end_initialize(ref YAML.Event event);
+
+		[CCode (cname="yaml_document_start_event_initialize")]
+		public static int document_start_initialize(ref YAML.Event event, void* version_directive = null, void* tag_directive_start = null, void* tag_directive_end = null,
+		                            bool implicit = true);
+
+		[CCode (cname="yaml_document_end_event_initialize")]
+		public static int document_end_initialize(ref YAML.Event event, bool implicit = true);
+
+		[CCode (cname="yaml_alias_event_initialize")]
+		public static int alias_initialize(ref YAML.Event event, string anchor);
+
+		[CCode (cname="yaml_scalar_event_initialize")]
+		public static int scalar_initialize(ref YAML.Event event, string? anchor, string? tag, string value, int length, 
+		                   bool plain_implicit = true, bool quoted_implicity = true, 
+		                   YAML.ScalarStyle style = YAML.ScalarStyle.ANY_SCALAR_STYLE );
+
+		[CCode (cname="yaml_sequence_start_event_initialize")]
+		public static int sequence_start_initialize(ref YAML.Event event, string? anchor = null, string? tag = null, bool implicit = true, YAML.SequenceStyle style = YAML.SequenceStyle.ANY_SEQUENCE_STYLE);
+		[CCode (cname="yaml_sequence_end_event_initialize")]
+		public static int sequence_end_initialize(ref YAML.Event event);
+
+		[CCode (cname="yaml_mapping_start_event_initialize")]
+		public static int mapping_start_initialize(ref YAML.Event event, string? anchor = null, string? tag = null, bool implicit = true, YAML.MappingStyle style = YAML.MappingStyle.ANY_MAPPING_STYLE);
+		[CCode (cname="yaml_mapping_end_event_initialize")]
+		public static int mapping_end_initialize(ref YAML.Event event);
+
+		public static void clean(ref YAML.Event event) {
+			event.type = YAML.EventType.NO_EVENT;
+		}
+		public EventType type;
+		public Mark start_mark;
+		public Mark end_mark;
+
+	}
+
+	/** 
+	 * The stream encoding. 
+	 * */
+	[CCode (cname = "yaml_encoding_t", cprefix="YAML_", has_type_id = false)]
+	public enum EncodingType {
+		/* Let the parser choose the encoding. */
+		ANY_ENCODING,
+		/* The default UTF-8 encoding. */
+		UTF8_ENCODING,
+		/* The UTF-16-LE encoding with BOM. */
+		UTF16LE_ENCODING,
+		/* The UTF-16-BE encoding with BOM. */
+		UTF16BE_ENCODING
+	}
+
+	/** Many bad things could happen with the parser and emitter. */
+	[CCode (cname="yaml_error_type_t", cprefix="YAML_", has_type_id=false)]
+	public enum ErrorType {
+		NO_ERROR,
+
+		/* Cannot allocate or reallocate a block of memory. */
+		MEMORY_ERROR,
+
+		/* Cannot read or decode the input stream. */
+		READER_ERROR,
+		/* Cannot scan the input stream. */
+		SCANNER_ERROR,
+		/* Cannot parse the input stream. */
+		PARSER_ERROR,
+		/* Cannot compose a YAML document. */
+		COMPOSER_ERROR,
+
+		/* Cannot write to the output stream. */
+		WRITER_ERROR,
+		/* Cannot emit a YAML stream. */
+		EMITTER_ERROR
+	}
+
+	[CCode (has_type_id = false,
+			cname="yaml_parser_t", 
+			lower_case_cprefix="yaml_parser_", 
+			destroy_function="yaml_parser_delete")]
+	public struct Parser {
+		public YAML.ErrorType error;
+		public string problem;
+		public size_t problem_offset;
+		public int problem_value;
+		public YAML.Mark problem_mark;
+		public string context;
+		public YAML.Mark context_mark;
+
+		public bool stream_start_produced;
+		public bool stream_end_produced;
+		[CCode (cname="yaml_parser_initialize")]
+		public Parser();
+
+		/*
+		 * Set the input to a string.
+		 *
+		 * libyaml doesn't take an ownership reference of the string.
+		 * Make sure you keep the string alive during the lifetime of
+		 * the parser!
+		 *
+		 * size is in bytes, not in characters. Use string.size() to obtain
+		 * the size.
+		 * */
+		public void set_input_string(string input, size_t size);
+		/*
+		 * Set the input to a file stream.
+		 *
+		 * libyaml doesn't take an ownership reference of the stream.
+		 * Make sure you keep the stream alive during the lifetime of
+		 * the parser!
+		 * */
+		public void set_input_file(GLib.FileStream file);
+		public void set_encoding(YAML.EncodingType encoding);
+		public bool parse(out YAML.Event event);
+	}
+
+	[CCode (instance_pos = 0, cname="yaml_write_handler_t")]
+	public delegate int WriteHandler(char[] buffer);
+
+	[CCode (has_type_id = false,
+			cname="yaml_emitter_t", 
+			lower_case_cprefix="yaml_emitter_", 
+			destroy_function="yaml_emitter_delete")]
+	public struct Emitter {
+		[CCode (cname="yaml_emitter_initialize")]
+		public Emitter();
+		/*
+		 * Set the output to a string.
+		 *
+		 * libyaml doesn't take an ownership reference of the string.
+		 * Make sure you keep the string alive during the lifetime of
+		 * the emitter!
+		 *
+		 * size is in bytes, not in characters. Use string.size() to obtain
+		 * the size.
+		 * */
+		public void set_output_string(char[] input, out size_t written);
+		/*
+		 * Set the output to a file stream.
+		 *
+		 * libyaml doesn't take an ownership reference of the stream.
+		 * Make sure you keep the stream alive during the lifetime of
+		 * the emitter!
+		 * */
+		public void set_output_file(GLib.FileStream file);
+
+		public void set_output(YAML.WriteHandler handler);
+
+		public void set_encoding(YAML.EncodingType encoding);
+		public void set_canonical(bool canonical);
+		public void set_indent(int indent);
+		public void set_width(int width);
+		public void set_unicode(bool unicode);
+		public void set_break(YAML.BreakType break);
+		public int emit(ref YAML.Event event);
+		public int flush();
+	}
+
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,4 @@
+test('parser', executable('parser-test', 'libyaml-glib-parser.vala',
+                          vala_args: ['--vapidir=' + meson.current_source_dir() + '/../src'],
+                          dependencies: [glib, gobject, yaml, yaml_glib]),
+     args: meson.current_source_dir() + '/invoice.yaml')


### PR DESCRIPTION
This is all we need to build the project with Meson.

With the coming 0.36, we'll be able to generate a specific header name (e.g. `yaml-glib-1.0/yaml-glib.h`).

I had to copy the whole `yaml-0.1.vapi` to keep autotools working. I'll push more commits for a full switch if it's convincing enough.
